### PR TITLE
fix: use password-only auth for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,6 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           password: ${{ secrets.SERVER_PASSWORD }}
-          key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.SERVER_PORT || '22' }}
           use_insecure_cipher: true
           cipher: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc"
@@ -204,7 +203,6 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           password: ${{ secrets.SERVER_PASSWORD }}
-          key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.SERVER_PORT || '22' }}
           source: "."
           target: "${{ secrets.PROJECT_PATH }}"
@@ -220,7 +218,6 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           password: ${{ secrets.SERVER_PASSWORD }}
-          key: ${{ secrets.SERVER_SSH_KEY }}
           port: ${{ secrets.SERVER_PORT || '22' }}
           use_insecure_cipher: true
           cipher: "aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc"
@@ -490,7 +487,10 @@ jobs:
               echo "Build failed with buildkit, trying standard build..."
               sudo docker compose -f docker-compose.prod.yml build --no-cache
             }
-            
+
+            # Re-enter project directory in case build step changed it
+            cd "${{ secrets.PROJECT_PATH }}" || exit 1
+
             echo "Starting containers..."
             if ! sudo docker compose -f docker-compose.prod.yml up -d; then
               echo "Failed to start containers"


### PR DESCRIPTION
## Summary
- remove unused SSH key references from deployment workflow
- rely on password authentication when uploading and deploying
- ensure deploy script returns to project directory before starting containers

## Testing
- `bun test` *(fails: Environment variable not found: DATABASE_URL)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ac480f0e083208aaf67c6f7936ae3