### PR TITLE
Handle read-only SSL volume in nginx entrypoint

### DIFF
--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -10,15 +10,13 @@ if [ -f "/etc/nginx/ssl/fullchain.crt" ]; then
     SSL_AVAILABLE=true
 elif [ -f "/etc/nginx/ssl/certificate.crt" ] && [ -f "/etc/nginx/ssl/certificate_ca.crt" ]; then
     echo "✓ Found certificate.crt and certificate_ca.crt"
-    # Try to create fullchain.crt if possible
-    if [ -w "/etc/nginx/ssl/" ]; then
-        cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt > /etc/nginx/ssl/fullchain.crt
+    # Try to create fullchain.crt if possible, but handle read-only volume gracefully
+    if cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt > /etc/nginx/ssl/fullchain.crt 2>/dev/null; then
         echo "✓ Created fullchain.crt from individual certificates"
-        SSL_AVAILABLE=true
     else
-        echo "✓ Using individual certificates (read-only volume)"
-        SSL_AVAILABLE=true
+        echo "✗ Failed to create fullchain.crt (read-only volume)"
     fi
+    SSL_AVAILABLE=true
 fi
 
 # Configure nginx based on SSL availability


### PR DESCRIPTION
## Summary
- avoid crashing nginx when SSL directory is read-only
- fallback to using existing certificate files and log the failure

## Testing
- `bash .gpt/run-tests.sh` (fails: `/home/user/projects/chase/backend` No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_689b235026608320ba42035d38c20072