### PR TITLE
Handle read-only SSL volume in nginx entrypoint

### DIFF
--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -10,23 +10,23 @@ if [ -f "/etc/nginx/ssl/fullchain.crt" ]; then
     SSL_AVAILABLE=true
 elif [ -f "/etc/nginx/ssl/certificate.crt" ] && [ -f "/etc/nginx/ssl/certificate_ca.crt" ]; then
     echo "✓ Found certificate.crt and certificate_ca.crt"
-    # Try to create fullchain.crt if possible
-    if [ -w "/etc/nginx/ssl/" ]; then
-        cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt > /etc/nginx/ssl/fullchain.crt
+    # Try to create fullchain.crt; suppress errors if volume is read-only
+    if cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt \
+        | tee /etc/nginx/ssl/fullchain.crt >/dev/null 2>/dev/null; then
         echo "✓ Created fullchain.crt from individual certificates"
-        SSL_AVAILABLE=true
     else
-        echo "✓ Using individual certificates (read-only volume)"
-        SSL_AVAILABLE=true
+        echo "✗ Failed to create fullchain.crt (read-only volume)"
     fi
+    SSL_AVAILABLE=true
 fi
 
 # Configure nginx based on SSL availability
 if [ "$SSL_AVAILABLE" = "true" ]; then
     echo "✓ SSL certificates found - using HTTPS configuration"
-    # Check if default.conf exists, if not copy the appropriate config
+    # Ensure default.conf exists by copying the HTTPS template if missing
     if [ ! -f "/etc/nginx/conf.d/default.conf" ]; then
         echo "! No default.conf found, using quattrex.pro.conf"
+        cp /etc/nginx/conf.d/quattrex.pro.conf /etc/nginx/conf.d/default.conf
     fi
 else
     echo "⚠ No SSL certificates found - using HTTP-only configuration"


### PR DESCRIPTION
## Summary
- suppress shell error when combining certificates on read-only volumes
- ensure HTTPS config is present by copying default template when missing

## Testing
- `bash .gpt/start-services.sh` (fails: `$'/home/user/projects/chase/backend\r': No such file or directory`)
- `bash .gpt/health-check.sh` (fails: `syntax error near unexpected token 'fi'`)
- `bash .gpt/run-tests.sh` (fails: `No such file or directory` for backend path)


------
https://chatgpt.com/codex/tasks/task_e_689b235026608320ba42035d38c20072