### PR TITLE
Handle read-only SSL volume and fix nginx proxy config

### DIFF
--- a/nginx/conf.d/quattrex.pro.conf
+++ b/nginx/conf.d/quattrex.pro.conf
@@ -41,7 +41,7 @@ server {
     
     # Main site
     location / {
-        proxy_pass http://frontend:3000;
+        proxy_pass http://frontend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -55,7 +55,7 @@ server {
     # API
     location /api {
         rewrite ^/api(.*)$ $1 break;
-        proxy_pass http://backend:3001;
+        proxy_pass http://backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -73,7 +73,7 @@ server {
     
     # Health check endpoints
     location /health {
-        proxy_pass http://backend:3001/health;
+        proxy_pass http://backend/health;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -10,23 +10,27 @@ if [ -f "/etc/nginx/ssl/fullchain.crt" ]; then
     SSL_AVAILABLE=true
 elif [ -f "/etc/nginx/ssl/certificate.crt" ] && [ -f "/etc/nginx/ssl/certificate_ca.crt" ]; then
     echo "✓ Found certificate.crt and certificate_ca.crt"
-    # Try to create fullchain.crt if possible
-    if [ -w "/etc/nginx/ssl/" ]; then
-        cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt > /etc/nginx/ssl/fullchain.crt
-        echo "✓ Created fullchain.crt from individual certificates"
-        SSL_AVAILABLE=true
+    # Only attempt to create fullchain.crt if the directory is writable
+    if [ -w "/etc/nginx/ssl" ]; then
+        if cat /etc/nginx/ssl/certificate.crt /etc/nginx/ssl/certificate_ca.crt \
+            > /etc/nginx/ssl/fullchain.crt 2>/dev/null; then
+            echo "✓ Created fullchain.crt from individual certificates"
+        else
+            echo "✗ Failed to create fullchain.crt"
+        fi
     else
-        echo "✓ Using individual certificates (read-only volume)"
-        SSL_AVAILABLE=true
+        echo "✗ Cannot create fullchain.crt (read-only volume)"
     fi
+    SSL_AVAILABLE=true
 fi
 
 # Configure nginx based on SSL availability
 if [ "$SSL_AVAILABLE" = "true" ]; then
     echo "✓ SSL certificates found - using HTTPS configuration"
-    # Check if default.conf exists, if not copy the appropriate config
+    # Ensure default.conf exists by copying the HTTPS template if missing
     if [ ! -f "/etc/nginx/conf.d/default.conf" ]; then
         echo "! No default.conf found, using quattrex.pro.conf"
+        cp /etc/nginx/conf.d/quattrex.pro.conf /etc/nginx/conf.d/default.conf
     fi
 else
     echo "⚠ No SSL certificates found - using HTTP-only configuration"


### PR DESCRIPTION
## Summary
- avoid writing `fullchain.crt` when SSL volume is read-only
- use upstream names instead of explicit ports in `quattrex.pro.conf`

## Testing
- `bash .gpt/start-services.sh` (fails: `$'\r': command not found` and missing backend path)
- `bash .gpt/health-check.sh` (fails: `$'\r': command not found` and syntax error near `fi`)
- `bash .gpt/run-tests.sh` (fails: `$'\r': command not found` and backend path missing)


------
https://chatgpt.com/codex/tasks/task_e_689b235026608320ba42035d38c20072